### PR TITLE
Add check for empty strings query validation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -479,8 +479,7 @@ describe('Query Builder', () => {
         expect(() =>
           queryBuilder.where(query, fieldOptions, fieldMetadata),
         ).toThrow(new Error('Missing value for field useremail'));
-
-      })
+      });
 
       it('should throw an error if the value is a JS null value', () => {
         const fieldOptions = [

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -455,6 +455,33 @@ describe('Query Builder', () => {
         );
       });
 
+      it('should throw an error if the trimmed value is an empty string', () => {
+        const fieldOptions = [
+          {
+            name: 'useremail',
+            type: 'medium',
+          },
+        ];
+
+        const query = {
+          id: '1',
+          combinator: 'or',
+          rules: [
+            {
+              id: '1',
+              field: 'useremail',
+              operator: '=',
+              value: '   ',
+            },
+          ],
+        };
+
+        expect(() =>
+          queryBuilder.where(query, fieldOptions, fieldMetadata),
+        ).toThrow(new Error('Missing value for field useremail'));
+
+      })
+
       it('should throw an error if the value is a JS null value', () => {
         const fieldOptions = [
           {

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ const getValue = (
     return undefined;
   }
 
-  if (value === '' || value === undefined || value === null) {
+  if (typeof value === 'string' && value.trim() === '' || value === undefined || value === null) {
     return handleMissingValue(options, `Missing value for field ${field}`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,11 @@ const getValue = (
     return undefined;
   }
 
-  if (typeof value === 'string' && value.trim() === '' || value === undefined || value === null) {
+  if (
+    (typeof value === 'string' && value.trim() === '') ||
+    value === undefined ||
+    value === null
+  ) {
     return handleMissingValue(options, `Missing value for field ${field}`);
   }
 


### PR DESCRIPTION
## Description

Currently the validator is not checking for strings with only whitespace. This PR adds to the validation in the `getValue` function.

## Rationale

Without these changes, a user can pass the validator without entering a valid value, by just entering a/multiple space(s). (eg: `'    '`)

## Checklist

Please check **one** of the below items. **Failure to do so will result in your PR being closed**:

- [x] I am on the Peak engineering team
- [ ] I am external to Peak and have **not** introduced any breaking changes
