### PR TITLE
Strips out association rank if it equals 'all'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peak-ai/query-builder",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Validate AIS-conformant query trees and serialise them as SQL strings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peak-ai/query-builder",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Validate AIS-conformant query trees and serialise them as SQL strings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -974,13 +974,11 @@ describe('Query Builder', () => {
               associationType: 'Brand',
               id: '1',
               field: 'associationvalue',
-              operator: '=',
-              value: 'Nike',
             },
           ],
         };
 
-        const expectedClause = `(associationtype = 'Brand' and associationvalue = 'Nike')`;
+        const expectedClause = `(associationtype = 'Brand' and associationvalue)`;
 
         expect(queryBuilder.where(query, fieldOptions, fieldMetadata)).toBe(
           expectedClause,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -974,6 +974,38 @@ describe('Query Builder', () => {
               associationType: 'Brand',
               id: '1',
               field: 'associationvalue',
+              operator: '=',
+              value: 'Nike',
+            },
+          ],
+        };
+
+        const expectedClause = `(associationtype = 'Brand' and associationvalue = 'Nike')`;
+
+        expect(queryBuilder.where(query, fieldOptions, fieldMetadata)).toBe(
+          expectedClause,
+        );
+      });
+
+      it('should omit the association rank from the query when its value is `All`', () => {
+        const fieldOptions = [
+          {
+            name: 'associationvalue',
+            type: 'small',
+            label: 'Brand',
+            autocomplete: true,
+          },
+        ];
+
+        const query = {
+          id: '1',
+          combinator: 'and',
+          rules: [
+            {
+              associationType: 'Brand',
+              associationRank: 'all',
+              id: '1',
+              field: 'associationvalue',
             },
           ],
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,11 @@ const isAssociatedQuery = (query: DefinedQuery): query is AssociatedQuery =>
 const hasRules = (query: RootQuery): query is DefinedRootQuery =>
   Boolean(query.rules && query.rules.length);
 
+const includeAssocationRank = (
+  { associationRankFieldName }: FieldMetadata,
+  associationRank?: string,
+) => associationRankFieldName && associationRank && associationRank !== 'all';
+
 const buildAssociativeQuery = (
   query: AssociatedQuery,
   fieldOptions: FieldOption[],
@@ -161,10 +166,9 @@ const buildAssociativeQuery = (
     builderOptions,
   );
 
-  const rankClause =
-    fieldMetadata.associationRankFieldName && associationRank
-      ? `${fieldMetadata.associationRankFieldName} = ${associationRank}`
-      : '';
+  const rankClause = includeAssocationRank(fieldMetadata, associationRank)
+    ? `${fieldMetadata.associationRankFieldName} = ${associationRank}`
+    : '';
 
   return [
     `${fieldMetadata.associationTypeFieldName} = '${associationType}'`,


### PR DESCRIPTION
<!--
Thank you for your contribution! 🙌🏻

Please consult the notes under each heading and respond
appropriately. Failing to do so will result in your PR
being rejected.

By submitting this pull request you hereby agree to us,
and others, using, modifying, and redistributing your
contribution as per the GNU GPL 3.0.
-->

## Description

Alls an association rank of `'all'` to be attached to queries.

## Rationale

A default value is required by our frontend `<select />` component, otherwise it renders an empty value.

## Checklist

Please check **one** of the below items. **Failure to do so will result in your PR being closed**:

- [x] I am on the Peak engineering team
- [ ] I am external to Peak and have **not** introduced any breaking changes
